### PR TITLE
feat: Add resume parsing functionality to FastAPI server

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ There is a clear need for an AI-powered, intuitive, and multilingual resume opti
 
 ### Core Functionality
 - **AI-Powered Resume Builder**: Create professional resumes from scratch using intelligent AI assistance
+- **Resume Parsing API**: Extract structured data from PDF resumes and plain text using hybrid local + AI parsing
 - **ATS Optimization**: Ensure your resume passes Applicant Tracking Systems with tailored formatting and keyword analysis
 - **LinkedIn Integration**: Import your professional profile data directly from LinkedIn
 - **GitHub Project Integration**: Showcase your technical projects and contributions

--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -10,6 +10,9 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY . .
 RUN uv pip install -e .
 
+# Install spaCy English model for resume parsing
+RUN python -m spacy download en_core_web_sm
+
 ENV PORT=7860
 EXPOSE $PORT
 

--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -10,22 +10,93 @@ sdk: docker
 # Backend API
 This directory contains the source code for the backend API, built using FastAPI.
 
+## Features
+- **Resume Parsing**: Extract structured data from PDF resumes and plain text
+- **Hybrid Parsing**: Uses both local spaCy-based parser and MCP server for enhanced results
+- **Multiple Input Formats**: Supports both PDF file uploads and raw text input
+
 ### Important Links
 - HuggingFace Repo: [https://huggingface.co/spaces/VIT-Bhopal-AI-Innovators-Hub/darzi-api-server](https://huggingface.co/spaces/VIT-Bhopal-AI-Innovators-Hub/darzi-api-server)
 - Deployment Link: [https://vit-bhopal-ai-innovators-hub-darzi-api-server.hf.space](https://vit-bhopal-ai-innovators-hub-darzi-api-server.hf.space)
 
+## API Endpoints
+
+### `/parse` (POST)
+Parse plain text resume data.
+- **Input**: Raw text (Content-Type: text/plain)
+- **Output**: Hybrid parsing results from both local parser and MCP server
+
+### `/parse-pdf` (POST) 
+Parse PDF resume file.
+- **Input**: PDF file upload (multipart/form-data)
+- **Output**: Structured resume data extracted from PDF
+
 ## Setup
 
-Using the provided Dockerfile, you can easily build and run the API container.
+### Local Development
+
+1. Install dependencies:
+```bash
+# Using uv (recommended)
+uv sync
+uv run python -m spacy download en_core_web_sm
+
+# Or using pip
+pip install -r requirements.txt
+python -m spacy download en_core_web_sm
+```
+
+2. Run the server:
+```bash
+python main.py
+# Server will be available at http://localhost:7860
+```
+
+### Testing the API
+
+#### Test Text Parsing:
+```bash
+curl -X POST http://localhost:7860/parse \
+  -H "Content-Type: text/plain" \
+  -d "John Doe. Email: john.doe@example.com. Phone: 1234567890. Python developer with 5 years experience at Google."
+```
+
+#### Test PDF Parsing:
+```bash
+# Replace 'path/to/your/resume.pdf' with your actual PDF file path
+curl -X POST http://localhost:7860/parse-pdf \
+  -F 'file=@path/to/your/resume.pdf'
+
+# Example paths:
+curl -X POST http://localhost:7860/parse-pdf -F 'file=@~/Downloads/resume.pdf'
+curl -X POST http://localhost:7860/parse-pdf -F 'file=@~/Desktop/my_resume.pdf'
+```
+
+#### Expected Response Format:
+```json
+{
+  "filename": "resume.pdf",
+  "parsing_result": {
+    "name": "John Doe",
+    "email": ["john.doe@example.com"],
+    "mobile_number": ["1234567890"],
+    "skills": ["Python", "JavaScript", "React"],
+    "education": ["Bachelor of Science", "University Name"],
+    "experience": [{"title": "Software Engineer", "company": "Google"}],
+    "raw_text": "First 500 characters of extracted text..."
+  },
+  "source": "local_parser"
+}
+```
+
+### Docker Deployment
 
 1. Build the Docker image:
-
 ```bash
 docker build -t darzi-backend-api .
 ```
 
 2. Run the Docker container:
-
 ```bash
 docker run -p 7860:7860 darzi-backend-api
 ```

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1,7 +1,9 @@
 import uvicorn
+import tempfile
+import os
 from fastmcp import Client
 from typing import Optional
-from fastapi import FastAPI, Request, HTTPException
+from fastapi import FastAPI, Request, HTTPException, UploadFile, File
 from fastapi.middleware.cors import CORSMiddleware
 
 from utils import ResumeParser
@@ -18,6 +20,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Initialize local parser
+resume_parser = ResumeParser()
 
 
 client: Optional[Client] = None
@@ -37,13 +42,79 @@ async def shutdown():
 
 @app.post("/parse")
 async def parse_plain(request: Request):
+    """Parse plain text resume using both local parser and MCP server"""
     body_bytes = await request.body()
     text = body_bytes.decode("utf-8").strip()
     if not text:
         raise HTTPException(status_code=400, detail="Empty body; send raw text with Content-Type: text/plain")
 
-    result = await client.call_tool("extract_data", {"text": text})
-    return result
+    # Use local parser for text-based parsing
+    try:
+        # Parse using local parser methods directly on text
+        local_result = {
+            "name": resume_parser.extract_name(text),
+            "email": resume_parser.extract_email(text),
+            "mobile_number": resume_parser.extract_phone(text),
+            "skills": resume_parser.extract_skills(text),
+            "education": resume_parser.extract_education(text),
+            "experience": resume_parser.extract_experience(text),
+            "raw_text": text[:500] + "..." if len(text) > 500 else text
+        }
+        
+        # Try to enhance with MCP if available
+        try:
+            mcp_result = await client.call_tool("extract_data", {"text": text})
+            return {
+                "local_parsing": local_result,
+                "mcp_parsing": mcp_result,
+                "source": "hybrid"
+            }
+        except Exception as mcp_error:
+            print(f"MCP parsing failed: {mcp_error}")
+            return {
+                "local_parsing": local_result,
+                "mcp_parsing": None,
+                "source": "local_only",
+                "mcp_error": str(mcp_error)
+            }
+            
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Parsing failed: {str(e)}")
+
+
+@app.post("/parse-pdf")
+async def parse_pdf(file: UploadFile = File(...)):
+    """Parse PDF resume file and extract structured data"""
+    if not file.filename.lower().endswith('.pdf'):
+        raise HTTPException(status_code=400, detail="Only PDF files are supported")
+    
+    try:
+        # Save uploaded file temporarily
+        with tempfile.NamedTemporaryFile(delete=False, suffix='.pdf') as tmp_file:
+            content = await file.read()
+            tmp_file.write(content)
+            tmp_path = tmp_file.name
+        
+        # Parse the PDF using local parser
+        result = resume_parser.parse_resume(tmp_path)
+        
+        # Clean up temp file
+        os.unlink(tmp_path)
+        
+        if "error" in result:
+            raise HTTPException(status_code=400, detail=result["error"])
+        
+        return {
+            "filename": file.filename,
+            "parsing_result": result,
+            "source": "local_parser"
+        }
+        
+    except Exception as e:
+        # Clean up temp file if it exists
+        if 'tmp_path' in locals() and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise HTTPException(status_code=500, detail=f"PDF parsing failed: {str(e)}")
 
 
 if __name__=="__main__":


### PR DESCRIPTION
- Add /parse endpoint for text-based resume parsing
- Add /parse-pdf endpoint for PDF file uploads
- Integrate local spaCy parser with comprehensive data extraction
- Add hybrid parsing with MCP server fallback capability
- Update Dockerfile to install required spaCy English model
- Enhanced documentation with clear API usage examples

Extracts: name, email, phone, skills, education, experience Returns clean JSON format as requested in issue #28

Fixes #28