### PR TITLE
Show User Name & Hide Login/Signup on Homepage When Authenticated

### DIFF
--- a/frontend/components/header.tsx
+++ b/frontend/components/header.tsx
@@ -5,6 +5,7 @@ import { Menu, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import React from 'react'
 import { cn } from '@/lib/utils'
+import { SignedIn, SignedOut, UserButton, useUser } from '@clerk/nextjs'
 
 const menuItems = [
     { name: 'Features', href: '#features' },
@@ -15,6 +16,7 @@ const menuItems = [
 const HeroHeader = () => {
     const [menuState, setMenuState] = React.useState(false)
     const [isScrolled, setIsScrolled] = React.useState(false)
+    const { user, isLoaded } = useUser();
 
     React.useEffect(() => {
         const handleScroll = () => {
@@ -75,33 +77,41 @@ const HeroHeader = () => {
                                     ))}
                                 </ul>
                             </div>
-                            {/* Keep existing buttons, just wire to Clerk routes */}
-                            <div className="flex w-full flex-col space-y-3 sm:flex-row sm:gap-3 sm:space-y-0 md:w-fit">
-                                <Button
-                                    asChild
-                                    variant="outline"
-                                    size="sm"
-                                    className={cn(isScrolled && 'lg:hidden')}>
-                                    <Link href="/sign-in">
-                                        <span>Login</span>
-                                    </Link>
-                                </Button>
-                                <Button
-                                    asChild
-                                    size="sm"
-                                    className={cn(isScrolled && 'lg:hidden')}>
-                                    <Link href="/sign-up">
-                                        <span>Sign Up</span>
-                                    </Link>
-                                </Button>
-                                <Button
-                                    asChild
-                                    size="sm"
-                                    className={cn(isScrolled ? 'lg:inline-flex' : 'hidden')}>
-                                    <Link href="/Dashboard">
-                                        <span>Get Started</span>
-                                    </Link>
-                                </Button>
+                            {/* Auth logic: show login/signup if signed out, user name & button if signed in */}
+                            <div className="flex w-full flex-col space-y-3 sm:flex-row sm:gap-3 sm:space-y-0 md:w-fit items-center">
+                                <SignedOut>
+                                    <Button
+                                        asChild
+                                        variant="outline"
+                                        size="sm"
+                                        className={cn(isScrolled && 'lg:hidden')}>
+                                        <Link href="/sign-in">
+                                            <span>Login</span>
+                                        </Link>
+                                    </Button>
+                                    <Button
+                                        asChild
+                                        size="sm"
+                                        className={cn(isScrolled && 'lg:hidden')}>
+                                        <Link href="/sign-up">
+                                            <span>Sign Up</span>
+                                        </Link>
+                                    </Button>
+                                </SignedOut>
+                                <SignedIn>
+                                    <span className="text-muted-foreground mr-2 hidden sm:inline-block">
+                                        {isLoaded ? user?.firstName || user?.username || 'User' : 'Loading...'}
+                                    </span>
+                                    <UserButton afterSignOutUrl="/" />
+                                    <Button
+                                        asChild
+                                        size="sm"
+                                        className={cn(isScrolled ? 'lg:inline-flex ml-2' : 'hidden ml-2')}>
+                                        <Link href="/Dashboard">
+                                            <span>Dashboard</span>
+                                        </Link>
+                                    </Button>
+                                </SignedIn>
                             </div>
                         </div>
                     </div>

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
         specifier: ^12.23.12
         version: 12.23.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next:
-        specifier: 15.4.5
+        specifier: ^15.4.5
         version: 15.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0


### PR DESCRIPTION
# Changes Made
- Updated header.tsx to use Clerk's authentication state.
- When signed in, the homepage header now displays the user’s name and the user button (with logout), and hides the login/signup buttons.
- When signed out, login/signup buttons are shown as before.
- This matches the dashboard header behavior and fixes the issue where login/signup was shown even when the user was authenticated.

# Screenshots  
<img width="2880" height="1336" alt="CleanShot 2025-08-30 at 07 57 40@2x" src="https://github.com/user-attachments/assets/0c7d3fa2-3ecd-42a1-8021-68fe8a31a7ff" />
Before - Homepage header shows Login/Signup buttons even when user is signed in.  
  
<img width="2880" height="1342" alt="CleanShot 2025-08-30 at 07 58 30@2x" src="https://github.com/user-attachments/assets/c9ef8439-42b5-490c-9ebc-1a5b56d8a729" />
After - Homepage header shows user’s name and user button, hides Login/Signup.  
  